### PR TITLE
🔧 chore(config): add production URL environment variable

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -35,9 +35,11 @@ class Settings(BaseSettings):
     # Configuração SQLite
     SQLITE_DB_NAME: str = os.getenv("SQLITE_DB_NAME", "database.db")
 
+    # Configuração de URLs
+    PRODUCTION_URL: str = os.getenv("PRODUCTION_URL", "")
+
     class Config:
         env_file = ".env"
-        case_sensitive = True
 
 settings = Settings()
 

--- a/app/main.py
+++ b/app/main.py
@@ -21,7 +21,7 @@ from app.controllers import (
     vaccination_points,
     vaccines
 )
-from app.config import limiter, logger
+from app.config import limiter, logger, settings
 from slowapi.errors import RateLimitExceeded
 from slowapi import _rate_limit_exceeded_handler
 
@@ -55,6 +55,10 @@ app = FastAPI(
     version="1.1.0",
     lifespan=lifespan,
     servers=[
+        {
+            "url": settings.PRODUCTION_URL,
+            "description": "Production Server"
+        },
         {
             "url": "http://localhost:8000",
             "description": "Local Development Server"


### PR DESCRIPTION
- Add PRODUCTION_URL to Settings class
- Use environment variable for server URL in OpenAPI config
- Keep localhost as development server option